### PR TITLE
Add authenticated user check before captcha load

### DIFF
--- a/src/managers/authentication/index.js
+++ b/src/managers/authentication/index.js
@@ -467,6 +467,10 @@ export default class Authentication {
 
             } else if (!this.reCaptcha.loaded && this.reCaptcha.enabled) {
 
+              if (this.isAuthenticated()) {
+                this.events.notify(EventsNames.local.FIREBASE_READY, true);
+              }
+
               this.events.subscribe(EventsNames.local.RECAPTCHA_LOADED, () => {
                 this.reCaptcha.initCaptchaProcess().then(() => {
                     this.events.notify(EventsNames.local.FIREBASE_READY, true);


### PR DESCRIPTION
A condition was added in the authentication manager to check if the user is authenticated before proceeding with the initialization of the captcha process. This is to ensure that the captcha process will not trigger unnecessarily for an authenticated user, minimizing unnecessary resource usage.